### PR TITLE
Fix test script to send POST requests instead of GET

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -32,6 +32,7 @@ cd "$parent_directory"
 
 for event in events/event-*.json; do
   curl \
+  --request POST\
   --data "@$event" \
   --header "Content-Type: application/json" \
   --connect-timeout 2 \


### PR DESCRIPTION
The provided test script was sending GET requests to the `/notifications` endpoint, but according to the `CHALLENGE.md` file, the service should accept JSON formatted POST messages on this endpoint.